### PR TITLE
Remove samsung authentication domains

### DIFF
--- a/smarttv.txt
+++ b/smarttv.txt
@@ -23,7 +23,6 @@ api.nfl.com
 api.us.hismarttv.com
 apicache.vudu.com
 arddigit.ivwbox.de
-auth.samsungosp.com
 az43064.vo.msecnd.net
 b02.black.ndmdhs.com
 bravia.dl.playstation.net
@@ -136,8 +135,6 @@ samsungacr.com
 samsungadhub.com
 samsungcloudsolution.com
 samsungcloudsolution.net
-samsungelectronics.com
-samsungosp.com
 samsungotn.net
 samsungqbe.com
 samsungrm.net


### PR DESCRIPTION
Hi there,

I don't know if this is intentional, but blocking `samsungosp.com` related domains will BREAK user authentication (i.e. logging into Samsung account)

I discovered this by accident with the similar issue:
https://imgur.com/gallery/9FxJ5

If this was not intentional, could you please unblock these domains by merging this pull request?

Thank you