### PR TITLE
Update fakenewsde.txt

### DIFF
--- a/fakenewsde.txt
+++ b/fakenewsde.txt
@@ -10,7 +10,6 @@ denken-macht-frei.info
 deutsch.rt.com
 deutsche-stimme.de
 deutsche-wirtschafts-nachrichten.de
-diepresse.com
 dortmundecho.org
 einwanderungskritik.de
 epochtimes.de


### PR DESCRIPTION
removed "diepresse.com" because it is actually a "quality" newspaper in Austria. 

See the wikipedia entry:
https://de.wikipedia.org/wiki/Die_Presse