### PR TITLE
Adding adware sites

### DIFF
--- a/other.txt
+++ b/other.txt
@@ -511,6 +511,7 @@ www.spooner-motorsport.com
 www.spyoff.com
 www.ssmobi.top
 www.stack-sonar.com
+www.startfenster.de
 www.sunmaker.com
 www.system-scan94.top
 www.taschengeld.com
@@ -521,6 +522,7 @@ www.traftosite.info
 www.usenetnl.icu
 www.vavoo.tv
 www.visit-x.net
+www.vlc.de
 www.vungle.com
 www.welzgxwtvto.bid
 www.youngvideoshd.com


### PR DESCRIPTION
VLC downwloaed from VLC.de instead of videolan.org changes all home URLs of browsers to (currently) www.startfenster.de. It also adds registry keys.